### PR TITLE
Fixed non-deterministic overload selection

### DIFF
--- a/SparrowImplicitLib/Check/Check.spr
+++ b/SparrowImplicitLib/Check/Check.spr
@@ -169,7 +169,7 @@ fun frequency(gens: Range): typeOf((#$gens.RetType)._2) if FreqGenType(#$gens.Re
     for ( fg = gens ) {
         sum += fg._1;
     }
-    if ( sum == 0 ) return gens.RetType();
+    if ( sum == 0 ) return typeOf((#$gens.RetType)._2)();
 
     // Select a random number in the total sum of frequencies
     var toSelect = randBetween(0, sum);

--- a/SparrowImplicitLib/Logic/LRef.spr
+++ b/SparrowImplicitLib/Logic/LRef.spr
@@ -150,8 +150,7 @@ fun mkLRef(x: @LRefType) = x;
 fun mkLRef(x: @StringRef) = LRef(String)(x);
 fun mkLRef(x: @AnyType): LRef(-@typeOf(x)) = x if !LRefType(x);
 
-fun mkValOrRef(x: @LRefType) = x;
-fun mkValOrRef(x: @ValWrapper) = x if !LRefType(typeOf(x));
+fun mkValOrRef(x: @ValWrapper) = x;
 fun mkValOrRef(x: @StringRef) = Optional(String)(x);
 fun mkValOrRef(x: @AnyType) = Optional(-@typeOf(x))(x) if !ValWrapper(x);
 

--- a/SparrowImplicitLib/SL/Algorithms.spr
+++ b/SparrowImplicitLib/SL/Algorithms.spr
@@ -31,7 +31,7 @@ fun min(value1: @AnyType, value2: @AnyType, pred: AnyType): typeOf(value1)
     return value1;
 }
 
-fun[autoCt] swap(a, b: @AnyType) if typeOf(a) == typeOf(b)
+fun[autoCt] swap(a, b: @AnyType) if typeOf(a) == typeOf(b) && !Swappable(a)
 {
     var tmp = a;
     a = b;

--- a/SparrowImplicitLib/SL/Bitset.spr
+++ b/SparrowImplicitLib/SL/Bitset.spr
@@ -22,7 +22,7 @@ class[rtct] Bitset
 
     fun clear
     {
-        memset(bits.begin.bytePtr(), UByte(0), bits.size());
+        memset(bits.begin.bytePtr(), Byte(0), bits.size());
     }
 
     private var bits: Array(UByte);

--- a/SparrowImplicitLib/SL/Ranges.spr
+++ b/SparrowImplicitLib/SL/Ranges.spr
@@ -175,7 +175,7 @@ class[rtct] NumericRangeInc(valueType: Type) if Number(#$valueType)
     fun back: RetType               = begin + cvt(size()-1);
     fun popBack                     { end -= step; }
 
-    fun size: SizeType              = ife(closed, end-begin+1, end-begin);
+    fun size: SizeType              = SizeType(ife(closed, valueType(end-begin+1), end-begin));
     
     fun popFront(n: SizeType)       { begin += cvt(n); }
     fun popBack(n: SizeType)        { end -= cvt(n); }

--- a/SparrowImplicitLib/SL/RawPtr.spr
+++ b/SparrowImplicitLib/SL/RawPtr.spr
@@ -25,6 +25,7 @@ class[rtct] RawPtr(valueType: Type)
 
     fun value: @ValueType               = ptr;
     fun advance: RawPtr                 = RawPtr.fromBytePtr(ptrAdd(bytePtr(), sizeOf(ValueType)));
+    fun advance(n: SizeType): RawPtr    = RawPtr.fromBytePtr(ptrAdd(bytePtr(), n * sizeOf(ValueType)));
     fun advance(n: DiffType): RawPtr    = RawPtr.fromBytePtr(ptrAdd(bytePtr(), n * DiffType(sizeOf(ValueType))));
     fun diff(other: RawPtr): DiffType   = DiffType(ptrDiff(bytePtr(), other.bytePtr()) / DiffType(sizeOf(ValueType)));
 

--- a/SparrowImplicitLib/SprCore/StdTypes.spr
+++ b/SparrowImplicitLib/SprCore/StdTypes.spr
@@ -17,7 +17,7 @@ class[native("i8"), noDefault, rtct] Byte
     fun[native("_zero_init_8")] ctor();
     fun[native("_ass_8_8")] ctor(src: Byte);
     fun[native("_ass_8_8")] ctor(src: Char);
-    fun[native("_ass_8_8"), convert] ctor(src: UByte);
+    fun[native("_ass_8_8")] ctor(src: UByte);
     fun[native("_ass_8_16")] ctor(src: Short);
     fun[native("_ass_8_16")] ctor(src: UShort);
     fun[native("_ass_8_32")] ctor(src: Int);
@@ -61,7 +61,7 @@ class[native("i16"), noDefault, rtct] Short
     fun[native("_ass_16_8s"), convert] ctor(src: Byte);
     fun[native("_ass_16_8z"), convert] ctor(src: UByte);
     fun[native("_ass_16_16")] ctor(src: Short);
-    fun[native("_ass_16_16"), convert] ctor(src: UShort);
+    fun[native("_ass_16_16")] ctor(src: UShort);
     fun[native("_ass_16_32")] ctor(src: Int);
     fun[native("_ass_16_32")] ctor(src: UInt);
     fun[native("_ass_16_64")] ctor(src: Long);
@@ -105,7 +105,7 @@ class[native("i32"), noDefault, rtct] Int
     fun[native("_ass_32_16s"), convert] ctor(src: Short);
     fun[native("_ass_32_16z"), convert] ctor(src: UShort);
     fun[native("_ass_32_32")] ctor(src: Int);
-    fun[native("_ass_32_32"), convert] ctor(src: UInt);
+    fun[native("_ass_32_32")] ctor(src: UInt);
     fun[native("_ass_32_64")] ctor(src: Long);
     fun[native("_ass_32_64")] ctor(src: ULong);
     fun[native("_ass_32_64")] ctor(src: SizeType);
@@ -151,7 +151,7 @@ class[native("i64"), noDefault, rtct] Long
     fun[native("_ass_64_32s"), convert] ctor(src: Int);
     fun[native("_ass_64_32z"), convert] ctor(src: UInt);
     fun[native("_ass_64_64")] ctor(src: Long);
-    fun[native("_ass_64_64"), convert] ctor(src: ULong);
+    fun[native("_ass_64_64")] ctor(src: ULong);
     fun[native("_ass_64_64"), convert] ctor(src: SizeType);
     fun[native("_ass_64_64"), convert] ctor(src: DiffType);
     fun[native("_ass_i64_f")] ctor(src: Float);
@@ -192,8 +192,8 @@ class[native("u64"), noDefault, rtct] SizeType
     fun[native("_ass_64_16z"), convert] ctor(src: UShort);
     fun[native("_ass_64_32z"), convert] ctor(src: Int);
     fun[native("_ass_64_32z"), convert] ctor(src: UInt);
-    fun[native("_ass_64_64"), convert] ctor(src: Long);
-    fun[native("_ass_64_64"), convert] ctor(src: ULong);
+    fun[native("_ass_64_64")] ctor(src: Long);
+    fun[native("_ass_64_64")] ctor(src: ULong);
     fun[native("_ass_64_64")] ctor(src: SizeType);
     fun[native("_ass_64_64"), convert] ctor(src: DiffType);
     fun[native("_ass_u64_f")] ctor(src: Float);
@@ -215,9 +215,9 @@ class[native("i64"), noDefault, rtct] DiffType
     fun[native("_ass_64_16z"), convert] ctor(src: UShort);
     fun[native("_ass_64_32s"), convert] ctor(src: Int);
     fun[native("_ass_64_32z"), convert] ctor(src: UInt);
-    fun[native("_ass_64_64"), convert] ctor(src: Long);
-    fun[native("_ass_64_64"), convert] ctor(src: ULong);
-    fun[native("_ass_64_64"), convert] ctor(src: SizeType);
+    fun[native("_ass_64_64")] ctor(src: Long);
+    fun[native("_ass_64_64")] ctor(src: ULong);
+    fun[native("_ass_64_64")] ctor(src: SizeType);
     fun[native("_ass_64_64")] ctor(src: DiffType);
     fun[native("_ass_i64_f")] ctor(src: Float);
     fun[native("_ass_i64_d")] ctor(src: Double);

--- a/src/SparrowFrontend/Helpers/Convert.cpp
+++ b/src/SparrowFrontend/Helpers/Convert.cpp
@@ -142,8 +142,10 @@ namespace
         if ( !srcConcept )
             return convNone;
 
+
         // If we have a concept, check if the type fulfills the concept
         TypeRef srcBaseConceptType = baseConceptType(srcConcept);
+        srcBaseConceptType = Feather_checkChangeTypeMode(srcBaseConceptType, srcType->mode, srcConcept->location);
         return cachedCanConvertImpl(context, flags, srcBaseConceptType, destType);
     }
     

--- a/src/SparrowFrontend/Helpers/Generics.cpp
+++ b/src/SparrowFrontend/Helpers/Generics.cpp
@@ -505,7 +505,6 @@ TypeRef SprFrontend::baseConceptType(Node* concept)
     Node* baseConcept = at(concept->children, 0);
 
     TypeRef res = baseConcept ? getType(baseConcept) : getConceptType();
-    res = Feather_adjustMode(res, concept->context, concept->location);
     return res;
 }
 

--- a/src/SparrowFrontend/Helpers/Overload.cpp
+++ b/src/SparrowFrontend/Helpers/Overload.cpp
@@ -208,9 +208,9 @@ namespace
             if ( !candidates[i]->isValid() )
                 continue;
             bool isMostSpecialized = true;
-            for ( size_t j=i+1; j<candidates.size(); ++j )
+            for ( size_t j=0; j<candidates.size(); ++j )
             {
-                if ( !candidates[j]->isValid() )
+                if ( j ==i || !candidates[j]->isValid() )
                     continue;
                 int res = moreSpecialized(context, candidates[i], candidates[j], noCustomCvt);
                 // if res < 0, the current function is more specialized than the other function

--- a/src/SparrowFrontend/Nodes/SparrowNodes_Exp.cpp
+++ b/src/SparrowFrontend/Nodes/SparrowNodes_Exp.cpp
@@ -1328,8 +1328,9 @@ Node* LambdaFunction_SemanticCheck(Node* node)
     // The actual enclosed function
     Nest_appendNodeToArray(&classBody->children, mkSprFunction(node->location, fromCStr("()"), parameters, returnType, body));
 
-    // Add a private default ctor
-    Nest_appendNodeToArray(&classBody->children, mkSprFunction(node->location, fromCStr("ctor"), nullptr, nullptr, Feather_mkLocalSpace(node->location, {}), nullptr, privateAccess));
+    // Add a private default ctor (only we have some closure parameters)
+    if ( closureParams && size(closureParams->children) > 0 )
+        Nest_appendNodeToArray(&classBody->children, mkSprFunction(node->location, fromCStr("ctor"), nullptr, nullptr, Feather_mkLocalSpace(node->location, {}), nullptr, privateAccess));
 
     // For each closure variable, create:
     // - a member variable in the class

--- a/tests/Basic/Overload.spr
+++ b/tests/Basic/Overload.spr
@@ -76,12 +76,12 @@ fun[native("test")] test(n: Int)
 
     //f3(a,10);
     f3(b,10);
-    f3(c,10);       // TODO: should be ambiguous here
+    //f3(c,10);
     writeLn("---");
 
     f3(a,Short(1));
     //f3(b,Short(1));
-    f3(c,Short(1));
+    //f3(c,Short(1));
 }
 
 /*<<<Running()
@@ -114,8 +114,6 @@ f2(Int, Int)
 f2(AnyType, AnyType)
 ---
 f3(Int, Int)
-f3(Double@, Double@)
 ---
 f3(AnyType, AnyType)
-f3(Double@, Double@)
 >>>*/

--- a/tests/Basic/SparrowImplicitLib.spr
+++ b/tests/Basic/SparrowImplicitLib.spr
@@ -922,7 +922,7 @@ class[native("i32"), noDefault, rtct] Int
 
 class[native("u32"), noDefault, rtct] UInt
 {
-    fun ctor() { this = 0; }
+    fun ctor() { this = UInt(0); }
     fun ctor(other: Uninitialized) {}
     fun[native("_ass_32_8z"), convert] ctor(src: Byte);
     fun[native("_ass_32_8z"), convert] ctor(src: UByte);
@@ -940,7 +940,7 @@ class[native("u32"), noDefault, rtct] UInt
 
 class[native("i64"), noDefault, rtct] Long
 {
-    fun ctor() { this = 0; }
+    fun ctor() { this = Long(0); }
     fun ctor(other: Uninitialized) {}
     fun[native("_ass_64_8s"), convert] ctor(src: Byte);
     fun[native("_ass_64_8z"), convert] ctor(src: UByte);
@@ -958,7 +958,7 @@ class[native("i64"), noDefault, rtct] Long
 
 class[native("u64"), noDefault, rtct] ULong
 {
-    fun ctor() { this = 0; }
+    fun ctor() { this = ULong(0); }
     fun ctor(other: Uninitialized) {}
     fun[native("_ass_64_8z"), convert] ctor(src: Byte);
     fun[native("_ass_64_8z"), convert] ctor(src: UByte);
@@ -1029,7 +1029,7 @@ class[native("i8"), noDefault, rtct] Char
 
 class[native("u64"), noDefault, rtct] SizeType
 {
-    fun ctor() { this = 0; }
+    fun ctor() { this = SizeType(0); }
     fun ctor(other: Uninitialized) {}
     fun[native("_ass_64_8z"), convert] ctor(src: Byte);
     fun[native("_ass_64_8z"), convert] ctor(src: UByte);
@@ -1084,7 +1084,7 @@ class[rtct, noDefault, native("StringRef")] StringRef
         var s = size();
         if ( s != other.size() ) return false;
         var i: SizeType = 0;
-        while ( i<s ; i+=1 )
+        while ( i<s ; i+=SizeType(1) )
             if ( getChar(i) != other.getChar(i) ) return false;
         return true;
     }

--- a/tests/Basic2/Swappable.spr
+++ b/tests/Basic2/Swappable.spr
@@ -3,7 +3,7 @@ package Test;
 
 concept Swappable(x) if isValid(x.swap(x));
 
-fun[autoCt] swap(a, b: @AnyType) if typeOf(a) == typeOf(b)
+fun[autoCt] swap(a, b: @AnyType) if typeOf(a) == typeOf(b) && !Swappable(a)
 {
     cout << "Simple swap called" << endl;
     var tmp = a;

--- a/tests/Examples/MinPerfHash.spr
+++ b/tests/Examples/MinPerfHash.spr
@@ -474,7 +474,7 @@ fun[rtct] getMonths: Vector(String)
 fun sprMain
 {
     var testNum = 1;
-    var keysCount: UInt = -1;
+    var keysCount: Int = -1;
     var testRepCount  = 1;
     var totalRepCount = 1;
     if ( programArgs.size() > 1 )  testNum = asInt(programArgs(1));

--- a/tests/PerfTests/Hash/TestHashPerf.spr
+++ b/tests/PerfTests/Hash/TestHashPerf.spr
@@ -23,7 +23,7 @@ class Equal(type: Type) {
 
 using ObjPtr = Ptr(Obj);
 using TestHashMap = Map(UInt, ObjPtr);
-using TestSortedMap = SortedMap(UInt, ObjPtr, Less(Int), Equal(Int));
+using TestSortedMap = SortedMap(UInt, ObjPtr, Less(UInt), Equal(UInt));
 
 var objects: Array(Obj);
 var insertKeys: Array(UInt);


### PR DESCRIPTION
The overload selection had a bug that he always preferred the last
overload. This is not only wrong, but it’s also non-deterministic.
Besides this fixed the lambdas not to create a second default ctor when
no bound arguments are present)