### PR TITLE
Add tracy profiling to the SparrowCompiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = externals/rapidcheck
 	url = https://github.com/emil-e/rapidcheck.git
 	branch = master
+[submodule "externals/tracy"]
+	path = externals/tracy
+	url = https://lucteo@bitbucket.org/wolfpld/tracy.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/SparrowCompiler/VersionInfo.h.in 
 # User passed compilation options
 option(BOOTSTRAP_SPARROW "Use system-wide SparrowCompiler to compile Sparrow files needed for the compiler" OFF)
 message(STATUS "BOOTSTRAP_SPARROW: ${BOOTSTRAP_SPARROW}")
+option(SPARROW_PROFILING "Enable Tracy integration into Sparrow compiler" OFF)
+message(STATUS "SPARROW_PROFILING: ${SPARROW_PROFILING}")
 
 # Where to output the results of the compilation
 set(OutDir ${CMAKE_CURRENT_SOURCE_DIR}/build/bin)
@@ -91,10 +93,16 @@ if(MSVC)
     add_definitions( -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE )
 else()
     add_definitions( -D__STDC_LIMIT_MACROS=1 )
-    set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++11" )
     # set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address" )
     add_definitions( -Wall )                    # All warnings...
     add_definitions( -Wno-deprecated )          # ... and except deprecated functions
+endif()
+
+if(SPARROW_PROFILING)
+    add_definitions( -DSPARROW_PROFILING=1 )
+    set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++17" )
+else()
+    set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++11" )
 endif()
 
 # Add our macros

--- a/Macros.cmake
+++ b/Macros.cmake
@@ -8,6 +8,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_program(SPARROW_EXECUTABLE_EXT NAMES SparrowCompiler DOC "path to the SparrowCompiler executable (external)")
 # Try to find an external llc executable
 find_program(LLC_EXECUTABLE_EXT NAMES spr-llc "${LLVM_TOOLS_BINARY_DIR}/llc" DOC "path to the llc executable (external)")
+# Try to find an external opt executable
+find_program(OPT_EXECUTABLE_EXT NAMES spr-opt "${LLVM_TOOLS_BINARY_DIR}/opt" DOC "path to the opt executable (external)")
 
 MACRO(GROUP_NAME_FROM_PATH filePath resultVar)
     IF(MSVC OR APPLE)
@@ -104,7 +106,7 @@ macro(LLVMASM_TARGET Name Input Output)
         endif()
 
         add_custom_command(OUTPUT ${LLVMASM_TARGET_outputs}
-            COMMAND ${LLC_EXECUTABLE_EXT} --filetype=obj ${LLVMASM_EXECUTABLE_opts} -o ${Output} ${Input}
+            COMMAND ${OPT_EXECUTABLE_EXT} -O2 ${Input} | ${LLC_EXECUTABLE_EXT} --filetype=obj ${LLVMASM_EXECUTABLE_opts} -o ${Output}
             VERBATIM
             DEPENDS ${Input} ${LLVMASM_TARGET_ARG_DEPENDS}
             COMMENT "[LLVM][${Name}] Building object ${Output}"

--- a/src/LLVMBackend/Tr/PrepareTranslate.cpp
+++ b/src/LLVMBackend/Tr/PrepareTranslate.cpp
@@ -8,6 +8,7 @@
 #include <Nest/Api/SourceCode.h>
 #include <Nest/Utils/cppif/NodeUtils.hpp>
 #include <Nest/Utils/Diagnostic.hpp>
+#include "Nest/Utils/Profiling.h"
 #include <Feather/Api/Feather.h>
 
 using namespace LLVMB;
@@ -28,6 +29,8 @@ bool isDecl(Node* node) {
 } // namespace
 
 void Tr::prepareTranslate(Node* node, GlobalContext& ctx) {
+    // PROFILING_ZONE();
+
     if (!node)
         return;
 

--- a/src/Nest/Api/NodeKindRegistrar.h
+++ b/src/Nest/Api/NodeKindRegistrar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "TypeRef.h"
+#include "Nest/Utils/ProfilingFwd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,6 +33,14 @@ FToString Nest_getToStringFun(int nodeKind);
 
 //! Resets the registered node kinds
 void Nest_resetRegisteredNodeKinds();
+
+#if SPARROW_PROFILING
+
+const Nest_Profiling_LocType* Nest_Profiling_getSetContextLoc(int nodeKind);
+const Nest_Profiling_LocType* Nest_Profiling_getComputeTypeLoc(int nodeKind);
+const Nest_Profiling_LocType* Nest_Profiling_getSemanticCheckLoc(int nodeKind);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/Nest/CMakeLists.txt
+++ b/src/Nest/CMakeLists.txt
@@ -69,7 +69,15 @@ SET(sourceFiles
     "src/Utils/cppif/StringRef.cpp"
     "src/Utils/cppif/Type.cpp"
     "src/Utils/cppif/TypeWithStorage.cpp"
+
 )
+if(SPARROW_PROFILING)
+    SET(sourceFiles
+        ${sourceFiles}
+        "src/Utils/Profiling.cpp"
+    )
+    add_definitions( -DSPARROW_PROFILING=1 )
+endif()
 
 # Project settings
 INCLUDE_DIRECTORIES( "." )

--- a/src/Nest/Utils/Profiling.h
+++ b/src/Nest/Utils/Profiling.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "ProfilingFwd.h"
+
+#if SPARROW_PROFILING
+
+#define TRACY_ENABLE 1
+
+#ifdef __cplusplus
+
+////////////////////////////////////////////////////////////////////////////////
+// C++ profiling definitions
+
+#include "../../../externals/tracy/Tracy.hpp"
+
+#include "Nest/Api/StringRef.h"
+
+#define PROFILING_ZONE() ZoneScoped
+#define PROFILING_ZONE_NAMED(staticName) ZoneScopedN(staticName)
+#define PROFILING_ZONE_TEXT(text)                                                                  \
+    ZoneScoped;                                                                                    \
+    _Nest_Profiling_zoneSetText(___tracy_scoped_zone, text)
+#define PROFILING_ZONE_NAMED_TEXT(staticName, text)                                                \
+    ZoneScopedN(staticName);                                                                       \
+    _Nest_Profiling_zoneSetText(___tracy_scoped_zone, text)
+#define PROFILING_ZONE_SETTEEXT(text) _Nest_Profiling_zoneSetText(___tracy_scoped_zone, text)
+
+#define PROFILING_PLOT(name, val) tracy::Profiler::PlotData(name, val)
+
+#define PROFILING_MESSAGE_STATIC(staticText) tracy::Profiler::Message(staticText)
+#define PROFILING_MESSAGE(text) _Nest_Profiling_message(text)
+
+inline void _Nest_Profiling_zoneSetText(tracy::ScopedZone& zone, const char* text) {
+    zone.Text(text, strlen(text));
+}
+inline void _Nest_Profiling_zoneSetText(tracy::ScopedZone& zone, Nest_StringRef text) {
+    zone.Text(text.begin, text.end - text.begin);
+}
+
+inline void _Nest_Profiling_message(const char* text) {
+    tracy::Profiler::Message(text, strlen(text));
+}
+inline void _Nest_Profiling_message(Nest_StringRef text) {
+    tracy::Profiler::Message(text.begin, text.end - text.begin);
+}
+
+#else // __cplusplus
+
+////////////////////////////////////////////////////////////////////////////////
+// C-only profiling definitions
+
+#include "../../../externals/tracy/TracyC.h"
+
+typedef TracyCZoneCtx Nest_Profiling_ZoneCtx;
+
+#define PROFILING_C_ZONE_BEGIN(ctx)                                                                \
+    static const struct Nest_Profiling_LocType TracyConcat(__tracy_source_location, __LINE__) = {  \
+            NULL, __FUNCTION__, __FILE__, (uint32_t)__LINE__, 0};                                  \
+    Nest_Profiling_ZoneCtx ctx =                                                                   \
+            ___tracy_emit_zone_begin(&TracyConcat(__tracy_source_location, __LINE__), 1);
+
+#define PROFILING_C_ZONE_BEGIN_LOC(ctx, locPtr)                                                    \
+    Nest_Profiling_ZoneCtx ctx = ___tracy_emit_zone_begin(locPtr, 1)
+
+#define PROFILING_C_ZONE_END(ctx) ___tracy_emit_zone_end(ctx)
+#define PROFILING_C_ZONE_SETTEEXT(ctx, text) ___tracy_emit_zone_text(ctx, text, strlen(text))
+
+#endif // __cplusplus
+
+////////////////////////////////////////////////////////////////////////////////
+// Both C and C++ profiling definitions
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! Creates a location type for profiling
+const Nest_Profiling_LocType* Nest_Profiling_createLoc(
+        const char* name, const char* function, const char* file, unsigned line, unsigned color);
+
+#ifdef __cplusplus
+}
+#endif
+
+#else // SPARROW_PROFILING
+
+////////////////////////////////////////////////////////////////////////////////
+// Profiling not enabled
+
+#define PROFILING_ZONE()                            /*nothing*/
+#define PROFILING_ZONE_NAMED(staticName)            /*nothing*/
+#define PROFILING_ZONE_TEXT(text)                   /*nothing*/
+#define PROFILING_ZONE_NAMED_TEXT(staticName, text) /*nothing*/
+#define PROFILING_ZONE_SETTEEXT(text)               /*nothing*/
+#define PROFILING_PLOT(name, val)                   /*nothing*/
+#define PROFILING_MESSAGE_STATIC(staticText)        /*nothing*/
+#define PROFILING_MESSAGE(text)                     /*nothing*/
+
+#define PROFILING_C_ZONE_BEGIN(ctx)             /*nothing*/
+#define PROFILING_C_ZONE_BEGIN_LOC(ctx, locPtr) /*nothing*/
+#define PROFILING_C_ZONE_END(ctx)               /*nothing*/
+#define PROFILING_C_ZONE_SETTEEXT(ctx, text)    /*nothing*/
+
+#endif

--- a/src/Nest/Utils/ProfilingFwd.h
+++ b/src/Nest/Utils/ProfilingFwd.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifndef SPARROW_PROFILING
+#define SPARROW_PROFILING 0
+#endif
+
+#if SPARROW_PROFILING
+
+//! Profiling type to store the source location data (from the compiler).
+//! Includes zone name, function name, filename, line number and color
+typedef struct ___tracy_source_location_data Nest_Profiling_LocType;
+
+#endif

--- a/src/Nest/src/Api/NodeKindRegistrar.c
+++ b/src/Nest/src/Api/NodeKindRegistrar.c
@@ -1,6 +1,10 @@
 #include "Nest/Api/NodeKindRegistrar.h"
 #include "Nest/Api/Node.h"
 #include "Nest/Utils/Assert.h"
+#include "Nest/Utils/Profiling.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 struct _NodeKindDescription {
     const char* name;
@@ -8,7 +12,24 @@ struct _NodeKindDescription {
     FComputeType funComputeType;
     FSetContextForChildren funSetContextForChildren;
     FToString funToString;
+
+#if SPARROW_PROFILING
+    const Nest_Profiling_LocType* setContextLoc;
+    const Nest_Profiling_LocType* computeTypeLoc;
+    const Nest_Profiling_LocType* semanticCheckLoc;
+#endif
 };
+
+#if SPARROW_PROFILING
+const char* strconcat(const char* s1, const char* s2) {
+    size_t len = strlen(s1) + strlen(s2) + 1;
+    char* res = (char*)malloc(len);
+    res[0] = 0;
+    strcat(res, s1);
+    strcat(res, s2);
+    return res;
+}
+#endif
 
 /// The registered node kinds
 struct _NodeKindDescription _allNodeKinds[1000];
@@ -24,9 +45,33 @@ int Nest_registerNodeKind(const char* name, FSemanticCheck funSemanticCheck,
         funSetContextForChildren = Nest_defaultFunSetContextForChildren;
     if (!funToString)
         funToString = Nest_defaultFunToString;
+
+#if SPARROW_PROFILING
+    const Nest_Profiling_LocType* setContextLoc =
+            Nest_Profiling_createLoc(strconcat("setCtx ", name), "Nest_setContext", "Node.c",
+                    1, 0x4f94cd); // SteelBlue3
+    const Nest_Profiling_LocType* computeTypeLoc =
+            Nest_Profiling_createLoc(strconcat("compType ", name), "Nest_computeType", "Node.c",
+                    1, 0x36648b); // SteelBlue4
+    const Nest_Profiling_LocType* semanticCheckLoc =
+            Nest_Profiling_createLoc(strconcat("semCheck ", name), "Nest_semanticCheck", "Node.c",
+                    1, 0x27408b); // RoyalBlue4
+#endif
+
     struct _NodeKindDescription nk = {
-            name, funSemanticCheck, funComputeType, funSetContextForChildren, funToString};
+        name,
+        funSemanticCheck,
+        funComputeType,
+        funSetContextForChildren,
+        funToString,
+#if SPARROW_PROFILING
+        setContextLoc,
+        computeTypeLoc,
+        semanticCheckLoc,
+#endif
+    };
     _allNodeKinds[nodeKindId] = nk;
+
     return nodeKindId;
 }
 
@@ -53,3 +98,17 @@ FToString Nest_getToStringFun(int nodeKind) {
 }
 
 void Nest_resetRegisteredNodeKinds() { _numNodeKinds = 0; }
+
+#if SPARROW_PROFILING
+
+const Nest_Profiling_LocType* Nest_Profiling_getSetContextLoc(int nodeKind) {
+    return _allNodeKinds[nodeKind].setContextLoc;
+}
+const Nest_Profiling_LocType* Nest_Profiling_getComputeTypeLoc(int nodeKind) {
+    return _allNodeKinds[nodeKind].computeTypeLoc;
+}
+const Nest_Profiling_LocType* Nest_Profiling_getSemanticCheckLoc(int nodeKind) {
+    return _allNodeKinds[nodeKind].semanticCheckLoc;
+}
+
+#endif

--- a/src/Nest/src/Utils/Profiling.cpp
+++ b/src/Nest/src/Utils/Profiling.cpp
@@ -1,0 +1,19 @@
+#include "Nest/Utils/Profiling.h"
+
+#if SPARROW_PROFILING
+
+// Include TracyClient.cpp after defining TRACY_ENABLE
+#include "../../../externals/tracy/TracyClient.cpp"
+
+extern "C" const Nest_Profiling_LocType* Nest_Profiling_createLoc(
+        const char* name, const char* function, const char* file, unsigned line, unsigned color) {
+    Nest_Profiling_LocType* loc = (Nest_Profiling_LocType*)malloc(sizeof(Nest_Profiling_LocType));
+    loc->name = name;
+    loc->function = function;
+    loc->file = file;
+    loc->line = line;
+    loc->color = color;
+    return loc;
+}
+
+#endif

--- a/src/Nest/src/Utils/cppif/NodeHandle.cpp
+++ b/src/Nest/src/Utils/cppif/NodeHandle.cpp
@@ -39,6 +39,8 @@ void NodeHandle::clearCompilationState() { Nest_clearCompilationState(handle); }
 
 const char* NodeHandle::toString() const { return Nest_getToStringFun(handle->nodeKind)(handle); }
 const char* NodeHandle::toStringEx() const {
+    if (!handle)
+        return "";
     ostringstream ss;
     ss << toString();
     if (handle->type)

--- a/src/SparrowCompiler/SparrowCompiler.cpp
+++ b/src/SparrowCompiler/SparrowCompiler.cpp
@@ -9,6 +9,7 @@
 #include "Nest/Utils/CompilerStats.hpp"
 #include "Nest/Utils/Diagnostic.hpp"
 #include "Nest/Utils/PrintTimer.hpp"
+#include "Nest/Utils/Profiling.h"
 #include "Nest/Utils/cppif/StringRef.hpp"
 #include "Nest/Api/Backend.h"
 #include "Nest/Api/CompilationContext.h"
@@ -172,6 +173,7 @@ void doCompilation(const vector<Nest_CompilerModule*>& modules) {
 
     // If we have no errors, start linking
     if (Nest_getErrorsNum() == 0 && !s.syntaxOnly_) {
+        PROFILING_ZONE_NAMED("Linking")
         try {
             Nest::Common::PrintTimer timer(s.verbose_, "", "[%d ms]\n");
             if (s.verbose_)

--- a/src/SparrowFrontend/CMakeLists.txt
+++ b/src/SparrowFrontend/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BOOTSTRAP_SPARROW)
     SPARROW_TARGET(SparrowParser
         ${CMAKE_CURRENT_SOURCE_DIR}/Grammar/parserIf.spr
         ${CMAKE_CURRENT_BINARY_DIR}/parserIf.o
-        COMPILE_FLAGS "-dump-assembly -fno-colors -fno-main -c"
+        COMPILE_FLAGS "-dump-assembly -fno-colors -fno-main -c -O2"
         DEPENDS Grammar/parser.spr
                 Grammar/parserDefs.spr
                 Grammar/ext.spr

--- a/src/SparrowFrontend/Services/Concepts/ConceptsServiceImpl.cpp
+++ b/src/SparrowFrontend/Services/Concepts/ConceptsServiceImpl.cpp
@@ -3,9 +3,13 @@
 #include "SparrowFrontend/Helpers/Generics.h"
 #include "SparrowFrontend/Helpers/SprTypeTraits.h"
 
+#include "Nest/Utils/Profiling.h"
+
 namespace SprFrontend {
 
 bool ConceptsServiceImpl::conceptIsFulfilled(ConceptDecl concept, Type type) {
+    PROFILING_ZONE();
+
     ASSERT(concept);
     auto instSet = concept.instantiationsSet();
 

--- a/src/SparrowFrontend/Services/Convert/ConvertServiceImpl.cpp
+++ b/src/SparrowFrontend/Services/Convert/ConvertServiceImpl.cpp
@@ -14,6 +14,7 @@
 #include "Feather/Utils/cppif/FeatherTypes.hpp"
 
 #include "Nest/Utils/Tuple.hpp"
+#include "Nest/Utils/Profiling.h"
 
 #include <utility>
 
@@ -407,6 +408,7 @@ bool ConvertServiceImpl::adjustReferences(ConversionResult& res, TypeWithStorage
 
 const ConversionResult& ConvertServiceImpl::cachedCheckConversion(
         CompilationContext* context, int flags, Type srcType, Type destType) {
+    PROFILING_ZONE();
 
     // Try to find the conversion in the map -- first, try without a source code
     KeyType key(srcType, destType, flags, nullptr);

--- a/src/SparrowFrontend/Services/Overload/OverloadServiceImpl.cpp
+++ b/src/SparrowFrontend/Services/Overload/OverloadServiceImpl.cpp
@@ -13,6 +13,8 @@
 #include "Feather/Utils/FeatherUtils.hpp"
 #include "Feather/Utils/cppif/FeatherNodes.hpp"
 
+#include "Nest/Utils/Profiling.h"
+
 using namespace SprFrontend;
 using namespace Nest;
 
@@ -172,6 +174,8 @@ void selectMostSpecializedErrReport(
 Node* OverloadServiceImpl::selectOverload(CompilationContext* context, const Location& loc,
         EvalMode evalMode, Nest_NodeRange decls, Nest_NodeRange args,
         OverloadReporting errReporting, StringRef funName) {
+    PROFILING_ZONE_TEXT(funName);
+
     auto numDecls = Nest_nodeRangeSize(decls);
     Node* firstDecl = numDecls > 0 ? at(decls, 0) : nullptr;
 
@@ -284,6 +288,8 @@ Node* OverloadServiceImpl::selectOverload(CompilationContext* context, const Loc
 
 bool OverloadServiceImpl::selectConversionCtor(
         CompilationContext* context, Node* destClass, EvalMode destMode, Type argType) {
+    PROFILING_ZONE();
+
     ASSERT(argType);
 
     // Get all the candidates
@@ -305,6 +311,8 @@ bool OverloadServiceImpl::selectConversionCtor(
 }
 
 Node* OverloadServiceImpl::selectCtToRtCtor(Node* ctArg) {
+    PROFILING_ZONE();
+
     const Location& loc = ctArg->location;
     ASSERT(ctArg->type);
     if (ctArg->type->mode != modeCt || !ctArg->type->hasStorage)

--- a/src/SparrowFrontend/SparrowSourceCode.cpp
+++ b/src/SparrowFrontend/SparrowSourceCode.cpp
@@ -5,6 +5,7 @@
 
 #include "Nest/Utils/Alloc.h"
 #include "Nest/Utils/Diagnostic.hpp"
+#include "Nest/Utils/Profiling.h"
 #include "Nest/Api/SourceCode.h"
 #include "Nest/Api/SourceCodeKindRegistrar.h"
 
@@ -16,8 +17,11 @@ namespace {
 void parseSourceCode(Nest_SourceCode* sourceCode, CompilationContext* ctx) {
     Location loc = Nest_mkLocation1(sourceCode, 1, 1);
 
-    Parser parser(loc);
-    sourceCode->mainNode = parser.parseModule();
+    {
+        PROFILING_ZONE_NAMED("parseModule");
+        Parser parser(loc);
+        sourceCode->mainNode = parser.parseModule();
+    }
 
     if (sourceCode->mainNode)
         Nest_setContext(sourceCode->mainNode, ctx);
@@ -54,6 +58,8 @@ void SprFe_registerSparrowSourceCode() {
 }
 
 Node* SprFe_parseSparrowExpression(Location loc, const char* code) {
+    PROFILING_ZONE();
+
     // Only use the start part of the location
     loc.end = loc.start;
 


### PR DESCRIPTION
Add tracy repository as external
Add Profiling options for Sparrow. If enabled, one can capture profiling
data while running the compiler.
Add scopes for most important operations (including Nest_setContext,
Nest_computeType and Nest_semanticCheck).

Make the compiler used optimized version of the parser.